### PR TITLE
Add messages param to asyncapi_operation; fix oneOf schema generation for variants

### DIFF
--- a/asyncapi-rust-codegen/src/asyncapi_spec_attrs.rs
+++ b/asyncapi-rust-codegen/src/asyncapi_spec_attrs.rs
@@ -62,6 +62,7 @@ pub struct OperationMeta {
     pub channel: String,
     #[allow(dead_code)] // Reserved for future use
     pub description: Option<String>,
+    pub messages: Vec<Path>,
 }
 
 /// Extract asyncapi spec metadata from `#[asyncapi(...)]` attributes
@@ -299,10 +300,14 @@ fn extract_channel_parameter(nested: &syn::meta::ParseNestedMeta) -> Option<Para
 
 /// Extract operation metadata from `#[asyncapi_operation(...)]` attribute
 fn extract_operation(attr: &Attribute) -> Option<OperationMeta> {
+    use syn::Token;
+    use syn::punctuated::Punctuated;
+
     let mut name = None;
     let mut action = None;
     let mut channel = None;
     let mut description = None;
+    let mut messages = Vec::new();
 
     let _ = attr.parse_nested_meta(|nested| {
         if nested.path.is_ident("name") {
@@ -321,6 +326,14 @@ fn extract_operation(attr: &Attribute) -> Option<OperationMeta> {
             let value = nested.value()?;
             let s: syn::LitStr = value.parse()?;
             description = Some(s.value());
+        } else if nested.path.is_ident("messages") {
+            // Parse array of type paths: messages = [Type1, Type2, ...]
+            let _ = nested.value()?; // Parse the equals sign and prepare for value parsing
+            let content;
+            syn::bracketed!(content in nested.input);
+            let types: Punctuated<Path, Token![,]> =
+                content.parse_terminated(|stream| stream.parse(), Token![,])?;
+            messages = types.into_iter().collect();
         }
         Ok(())
     });
@@ -331,6 +344,7 @@ fn extract_operation(attr: &Attribute) -> Option<OperationMeta> {
         action: action?,
         channel: channel?,
         description,
+        messages,
     })
 }
 
@@ -605,5 +619,54 @@ mod tests {
         assert_eq!(param1.name, "userId");
         assert_eq!(param1.schema_type, Some("integer".to_string()));
         assert_eq!(param1.format, Some("int64".to_string()));
+    }
+
+    #[test]
+    fn test_extract_operation_with_messages() {
+        let attrs: Vec<Attribute> = vec![parse_quote! {
+            #[asyncapi_operation(name = "sendMessage", action = "send", channel = "chat", messages = [ChatMessage])]
+        }];
+
+        let meta = extract_asyncapi_spec_meta(&attrs);
+        assert_eq!(meta.operations.len(), 1);
+        assert_eq!(meta.operations[0].name, "sendMessage");
+        assert_eq!(meta.operations[0].action, "send");
+        assert_eq!(meta.operations[0].channel, "chat");
+        assert_eq!(meta.operations[0].messages.len(), 1);
+        let path0 = &meta.operations[0].messages[0];
+        assert_eq!(quote!(#path0).to_string(), "ChatMessage");
+    }
+
+    #[test]
+    fn test_extract_operation_with_multiple_messages() {
+        let attrs: Vec<Attribute> = vec![parse_quote! {
+            #[asyncapi_operation(name = "sendMessage", action = "send", channel = "chat", messages = [ChatMessage, SystemMessage])]
+        }];
+
+        let meta = extract_asyncapi_spec_meta(&attrs);
+        assert_eq!(meta.operations.len(), 1);
+        assert_eq!(meta.operations[0].messages.len(), 2);
+        let path0 = &meta.operations[0].messages[0];
+        let path1 = &meta.operations[0].messages[1];
+        assert_eq!(quote!(#path0).to_string(), "ChatMessage");
+        assert_eq!(quote!(#path1).to_string(), "SystemMessage");
+    }
+
+    #[test]
+    fn test_extract_operation_with_module_path_messages() {
+        let attrs: Vec<Attribute> = vec![parse_quote! {
+            #[asyncapi_operation(name = "sendMessage", action = "send", channel = "chat", messages = [super::messages::ChatMessage, crate::SystemMessage])]
+        }];
+
+        let meta = extract_asyncapi_spec_meta(&attrs);
+        assert_eq!(meta.operations.len(), 1);
+        assert_eq!(meta.operations[0].messages.len(), 2);
+        let path0 = &meta.operations[0].messages[0];
+        let path1 = &meta.operations[0].messages[1];
+        assert_eq!(
+            quote!(#path0).to_string(),
+            "super :: messages :: ChatMessage"
+        );
+        assert_eq!(quote!(#path1).to_string(), "crate :: SystemMessage");
     }
 }

--- a/asyncapi-rust/examples/schema_inspection.rs
+++ b/asyncapi-rust/examples/schema_inspection.rs
@@ -1,0 +1,41 @@
+use schemars::{JsonSchema, schema_for};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type")]
+pub enum TestMessage {
+    Echo { text: String },
+    Broadcast { room: String, text: String },
+}
+
+fn main() {
+    // Get the schema for the full enum
+    let root_schema = schema_for!(TestMessage);
+    println!("=== Full Enum Schema ===");
+    let schema_json = serde_json::to_string_pretty(&root_schema).unwrap();
+    println!("{}", schema_json);
+
+    // Parse back to see the structure
+    let schema_value: serde_json::Value = serde_json::from_str(&schema_json).unwrap();
+
+    if let Some(one_of_array) = schema_value.get("oneOf") {
+        println!("\n=== Found oneOf ===");
+        if let Some(variants) = one_of_array.as_array() {
+            println!("Number of oneOf variants: {}", variants.len());
+            for (idx, variant) in variants.iter().enumerate() {
+                println!("\n--- Variant {} ---", idx);
+
+                // Check if this variant has a const field for the type
+                if let Some(props) = variant.get("properties") {
+                    if let Some(type_prop) = props.get("type") {
+                        if let Some(const_val) = type_prop.get("const") {
+                            println!("Type const value: {}", const_val);
+                        }
+                    }
+                }
+
+                println!("{}", serde_json::to_string_pretty(variant).unwrap());
+            }
+        }
+    }
+}

--- a/asyncapi-rust/examples/test_oneof.rs
+++ b/asyncapi-rust/examples/test_oneof.rs
@@ -1,0 +1,25 @@
+use asyncapi_rust::{ToAsyncApiMessage, schemars::JsonSchema};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, JsonSchema, ToAsyncApiMessage)]
+#[serde(tag = "type")]
+pub enum TestMessage {
+    Echo { text: String },
+    Broadcast { room: String, text: String },
+}
+
+fn main() {
+    let messages = TestMessage::asyncapi_messages();
+
+    println!("Number of messages: {}", messages.len());
+
+    for (idx, msg) in messages.iter().enumerate() {
+        println!("\n=== Message {} ===", idx);
+        println!("Name: {:?}", msg.name);
+        println!("Payload:");
+        if let Some(ref payload) = msg.payload {
+            let json = serde_json::to_string_pretty(payload).unwrap();
+            println!("{}", json);
+        }
+    }
+}

--- a/asyncapi-rust/src/lib.rs
+++ b/asyncapi-rust/src/lib.rs
@@ -42,8 +42,9 @@
 //! #[asyncapi(title = "Chat API", version = "1.0.0")]
 //! #[asyncapi_server(name = "production", host = "api.example.com", protocol = "wss")]
 //! #[asyncapi_channel(name = "chat", address = "/ws/chat")]
-//! #[asyncapi_operation(name = "sendMessage", action = "send", channel = "chat")]
-//! #[asyncapi_operation(name = "receiveMessage", action = "receive", channel = "chat")]
+//! #[asyncapi_operation(name = "sendMessage", action = "send", channel = "chat", messages = [ChatMessage])]
+//! #[asyncapi_operation(name = "receiveMessage", action = "receive", channel = "chat", messages = [ChatMessage])]
+//! #[asyncapi_messages(ChatMessage)]
 //! struct ChatApi;
 //!
 //! fn main() {
@@ -76,7 +77,13 @@
 //! - `#[asyncapi(...)]` - Basic info (title, version, description)
 //! - `#[asyncapi_server(...)]` - Server definitions
 //! - `#[asyncapi_channel(...)]` - Channel definitions
-//! - `#[asyncapi_operation(...)]` - Operation definitions
+//! - `#[asyncapi_operation(...)]` - Operation definitions (with optional `messages` parameter)
+//! - `#[asyncapi_messages(...)]` - Include message types in components
+//!
+//! When you specify messages in operations, they are automatically added to the channel
+//! that the operation references. Operations reference channel messages
+//! (`#/channels/{channel}/messages/{message}`), while channels reference components
+//! (`#/components/messages/{message}`), following AsyncAPI 3.0 specification.
 //!
 //! ## Framework Integration
 //!

--- a/asyncapi-rust/tests/integration_test.rs
+++ b/asyncapi-rust/tests/integration_test.rs
@@ -408,3 +408,88 @@ fn test_asyncapi_with_messages() {
     assert_eq!(system_status.name, Some("system.status".to_string()));
     assert_eq!(system_status.summary, Some("System status".to_string()));
 }
+
+#[test]
+fn test_asyncapi_operation_with_messages() {
+    // Define message types for operations
+    #[derive(Serialize, Deserialize, JsonSchema, ToAsyncApiMessage)]
+    #[serde(tag = "type")]
+    pub enum ChatMessage {
+        #[serde(rename = "user.join")]
+        UserJoin { username: String, room: String },
+        #[serde(rename = "chat.message")]
+        ChatMessage { username: String, text: String },
+    }
+
+    #[derive(Serialize, Deserialize, JsonSchema, ToAsyncApiMessage)]
+    #[serde(tag = "type")]
+    pub enum SystemMessage {
+        #[serde(rename = "system.status")]
+        Status { status: String },
+    }
+
+    // Define API with operations that specify messages
+    #[allow(clippy::duplicated_attributes)]
+    #[derive(AsyncApi)]
+    #[asyncapi(title = "Chat API", version = "1.0.0")]
+    #[asyncapi_channel(name = "chat", address = "/ws/chat")]
+    #[asyncapi_operation(name = "sendMessage", action = "send", channel = "chat", messages = [ChatMessage])]
+    #[asyncapi_operation(name = "receiveMessage", action = "receive", channel = "chat", messages = [ChatMessage, SystemMessage])]
+    #[asyncapi_messages(ChatMessage, SystemMessage)]
+    struct ChatApi;
+
+    let spec = ChatApi::asyncapi_spec();
+
+    // Verify operations exist
+    let operations = spec.operations.expect("Should have operations");
+    assert_eq!(operations.len(), 2);
+
+    // Verify sendMessage operation has messages
+    let send_op = operations
+        .get("sendMessage")
+        .expect("Should have sendMessage operation");
+    assert!(send_op.messages.is_some());
+    let send_messages = send_op.messages.as_ref().unwrap();
+    assert_eq!(send_messages.len(), 2); // ChatMessage has 2 variants
+
+    // Verify receiveMessage operation has messages
+    let receive_op = operations
+        .get("receiveMessage")
+        .expect("Should have receiveMessage operation");
+    assert!(receive_op.messages.is_some());
+    let receive_messages = receive_op.messages.as_ref().unwrap();
+    assert_eq!(receive_messages.len(), 3); // ChatMessage (2 variants) + SystemMessage (1 variant)
+
+    // Verify operation message references point to channel messages (not components directly)
+    match &send_messages[0] {
+        asyncapi_rust::MessageRef::Reference { reference } => {
+            assert!(
+                reference == "#/channels/chat/messages/user.join"
+                    || reference == "#/channels/chat/messages/chat.message"
+            );
+        }
+        _ => panic!("Expected message reference"),
+    }
+
+    // Verify channels exist and have messages
+    let channels = spec.channels.expect("Should have channels");
+    assert_eq!(channels.len(), 1);
+
+    let chat_channel = channels.get("chat").expect("Should have chat channel");
+    assert!(chat_channel.messages.is_some());
+    let channel_messages = chat_channel.messages.as_ref().unwrap();
+    assert_eq!(channel_messages.len(), 3); // All unique messages from both operations
+
+    // Verify channel messages reference components directly
+    assert!(channel_messages.contains_key("user.join"));
+    assert!(channel_messages.contains_key("chat.message"));
+    assert!(channel_messages.contains_key("system.status"));
+
+    // Verify channel messages reference components (not other channels)
+    match channel_messages.get("user.join").unwrap() {
+        asyncapi_rust::MessageRef::Reference { reference } => {
+            assert_eq!(reference, "#/components/messages/user.join");
+        }
+        _ => panic!("Expected message reference"),
+    }
+}

--- a/asyncapi-rust/tests/integration_test.rs
+++ b/asyncapi-rust/tests/integration_test.rs
@@ -118,13 +118,59 @@ fn test_enum_schema_generation() {
     let messages = TaggedMessage::asyncapi_messages();
     assert_eq!(messages.len(), 2);
 
-    // Each variant should have its own message
-    assert_eq!(messages[0].name, Some("Echo".to_string()));
-    assert_eq!(messages[1].name, Some("Broadcast".to_string()));
+    // Find messages by name (more maintainable than hard-coded indices)
+    let echo_msg = messages
+        .iter()
+        .find(|m| m.name.as_ref().is_some_and(|n| n == "Echo"))
+        .expect("Echo message should exist");
+
+    let broadcast_msg = messages
+        .iter()
+        .find(|m| m.name.as_ref().is_some_and(|n| n == "Broadcast"))
+        .expect("Broadcast message should exist");
 
     // Both should have schemas
-    assert!(messages[0].payload.is_some());
-    assert!(messages[1].payload.is_some());
+    assert!(echo_msg.payload.is_some());
+    assert!(broadcast_msg.payload.is_some());
+
+    // Verify that each message has ONLY its specific variant schema (no oneOf)
+    // Convert to JSON to inspect the structure
+    let echo_payload_json = serde_json::to_value(&echo_msg.payload).unwrap();
+    let broadcast_payload_json = serde_json::to_value(&broadcast_msg.payload).unwrap();
+
+    // Echo message should NOT have oneOf at the top level
+    assert!(
+        echo_payload_json.get("oneOf").is_none(),
+        "Echo message should not have oneOf in its schema"
+    );
+
+    // Broadcast message should NOT have oneOf at the top level
+    assert!(
+        broadcast_payload_json.get("oneOf").is_none(),
+        "Broadcast message should not have oneOf in its schema"
+    );
+
+    // Echo message should have the const value "Echo" in its type property
+    if let Some(properties) = echo_payload_json.get("properties") {
+        if let Some(type_prop) = properties.get("type") {
+            assert_eq!(
+                type_prop.get("const"),
+                Some(&serde_json::json!("Echo")),
+                "Echo message should have const 'Echo' in type property"
+            );
+        }
+    }
+
+    // Broadcast message should have the const value "Broadcast" in its type property
+    if let Some(properties) = broadcast_payload_json.get("properties") {
+        if let Some(type_prop) = properties.get("type") {
+            assert_eq!(
+                type_prop.get("const"),
+                Some(&serde_json::json!("Broadcast")),
+                "Broadcast message should have const 'Broadcast' in type property"
+            );
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Description

This PR adds two features to `asyncapi-rust` for better AsyncAPI spec generation from Rust code: improved `oneOf` field merging in message schemas and a new `messages` parameter in the `#[asyncapi_operation]` attribute (applied to API structs like `MyApi`; see examples/tests for usage).

## Changes

### 1. OneOf Field Merging in Message Schemas
Fixes schema generation for enum variants (e.g., with `serde` tagging) by extracting and applying individual schemas separately, avoiding broad `oneOf` arrays. Improves precision and alignment with Rust types.

**Example with oneOf Issue:**
```rust
#[derive(Serialize, Deserialize, JsonSchema, ToAsyncApiMessage)]
#[serde(tag = "type")]
pub enum TestMessage {
    Echo { text: String },
    Broadcast { room: String, text: String },
}
```
- **Before:** Generated a single schema with `oneOf` array for all variants (causing validation issues and inaccurate docs).
- **After:** Generates separate messages (`Echo`, `Broadcast`) with distinct schemas, including `const` for tagging (no top-level `oneOf`).

### 2. `messages` Parameter for Operations
Adds `messages` to `#[asyncapi_operation]` for associating multiple messages directly. Applied to API structs (e.g., `MyApi`).

**Usage:**
```rust
#[derive(AsyncApi)]GL switches keycaps
#[asyncapi(title = "Chat API", version = "1.0.0")]
#[asyncapi_channel(name = "chat", address = "/ws/chat")]
#[asyncapi_operation(
    name = "sendMessage",
    action = "send",
    channel = "chat",
    messages = [ChatMessage]
)]
#[asyncapi_operation(
    name = "receiveMessage",
    action = "receive",
    channel = "chat",
    messages = [ChatMessage, SystemMessage]
)]
#[asyncapi_messages(ChatMessage, SystemMessage)]
struct ChatApi;
```
Enhances configurability for polymorphic messages.

## Motivation
Addresses needs for union types and simplified operation definitions. Additive, no breaking changes.

## Testing
- Verified JSON output for variants and multi-messages.

Review appreciated!